### PR TITLE
useEffect was declared but never read

### DIFF
--- a/ripple.ts
+++ b/ripple.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useRef } from "react";
 
 export type Options<T extends HTMLElement = any> = {
     duration: number;


### PR DESCRIPTION
fixes linter error: `error TS6133: 'useEffect' is declared but its value is never read.`